### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ GPLv3
 
 [Appveyor]:       https://ci.appveyor.com/project/clowwindy/shadowsocks-csharp
 [Build Status]:   https://ci.appveyor.com/api/projects/status/gknc8l1lxy423ehv/branch/master
-[latest release]: https://github.com/shadowsocks/shadowsocks-csharp/releases
+[latest release]: https://github.com/shadowsocks/shadowsocks-windows/releases


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/shadowsocks/shadowsocks-csharp/releases | https://github.com/shadowsocks/shadowsocks-windows/releases 
